### PR TITLE
Use uaa client to authenticate to cloud foundry.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -30,8 +30,8 @@ jobs:
       BUCKET_PREFIX: {{staging-bucket-prefix}}
       IAM_PATH: {{staging-iam-path}}
       CF_API_URL: {{staging-cf-api-url}}
-      CF_USERNAME: {{staging-cf-username}}
-      CF_PASSWORD: {{staging-cf-password}}
+      CF_CLIENT_ID: {{staging-cf-client-id}}
+      CF_CLIENT_SECRET: {{staging-cf-client-secret}}
       AWS_PARTITION: aws-us-gov
   - put: deploy-s3-broker-app-staging
     params:
@@ -129,8 +129,8 @@ jobs:
       BUCKET_PREFIX: {{production-bucket-prefix}}
       IAM_PATH: {{production-iam-path}}
       CF_API_URL: {{production-cf-api-url}}
-      CF_USERNAME: {{production-cf-username}}
-      CF_PASSWORD: {{production-cf-password}}
+      CF_CLIENT_ID: {{production-cf-client-id}}
+      CF_CLIENT_SECRET: {{production-cf-client-secret}}
       AWS_PARTITION: aws-us-gov
   - put: deploy-s3-broker-app-production
     params:

--- a/tasks/build.sh
+++ b/tasks/build.sh
@@ -15,8 +15,8 @@ s3_config:
   iam_path: "${IAM_PATH}"
 cf_config:
   api_url: "${CF_API_URL}"
-  user: "${CF_USERNAME}"
-  password: "${CF_PASSWORD}"
+  client_id: "${CF_CLIENT_ID}"
+  client_secret: "${CF_CLIENT_SECRET}"
 EOF
 
 cp -r broker-src/. broker-src-built


### PR DESCRIPTION
* Use client instead of user
* Switch to read-only authority

Working on staging, will unpause production after cf-production rolls out with the new uaa client.