### PR TITLE
Add plan for sandbox orgs

### DIFF
--- a/config-template.yml
+++ b/config-template.yml
@@ -127,3 +127,33 @@ s3_config:
               ]
             }
           encryption: *encryption
+      - id: 81194F9D-B29E-485F-866A-CA3861D511AB
+        name: basic-public-sandbox
+        description: A single public bucket with unlimited storage, where the files are all public to read.  Plan is exclusive to sandbox accounts, S3 storage is cleared when service is deleted.
+        free: true
+        durable: true
+        metadata:
+          bullets:
+          - Single S3 bucket
+          - Unlimited storage, unlimited number of objects
+          - Files are deleted from S3 when service is deleted.
+          costs:
+          - amount:
+              usd: 0.03
+            unit: Per GB
+        s3_properties:
+          iam_policy: *iam-policy
+          bucket_policy: |-
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Principal": "*",
+                  "Action": ["s3:GetObject"],
+                  "Resource": ["arn:{{.AwsPartition}}:s3:::{{.BucketName}}/*"]
+                }
+              ]
+            }
+          encryption: *encryption
+

--- a/config-template.yml
+++ b/config-template.yml
@@ -158,4 +158,23 @@ s3_config:
               ]
             }
           encryption: *encryption
+      - id: 45EB0749-49F1-427B-B6F5-BA6B24894CA7
+        name: basic-sandbox
+        description: A single private bucket with unlimited storage.  Plan is exclusive to sandbox accounts, S3 storage is cleared when service is deleted.
+        free: true
+        durable: false
+        metadata:
+          bullets:
+          - Single S3 bucket
+          - Unlimited storage, unlimited number of objects
+          - Files are deleted from S3 when service is deleted.
+          costs:
+          - amount:
+              usd: 0.03
+            unit: Per GB
+        s3_properties:
+          iam_policy: *iam-policy
+          encryption: *encryption
+
+
 

--- a/config-template.yml
+++ b/config-template.yml
@@ -30,6 +30,7 @@ s3_config:
         name: basic
         description: A single private bucket with unlimited storage
         free: true
+        durable: true
         metadata:
           bullets:
           - Single S3 bucket
@@ -104,6 +105,7 @@ s3_config:
         name: basic-public
         description: A single public bucket with unlimited storage, where the files are all public to read
         free: true
+        durable: true
         metadata:
           bullets:
           - Single S3 bucket

--- a/config-template.yml
+++ b/config-template.yml
@@ -133,7 +133,7 @@ s3_config:
         name: basic-public-sandbox
         description: A single public bucket with unlimited storage, where the files are all public to read.  Plan is exclusive to sandbox accounts, S3 storage is cleared when service is deleted.
         free: true
-        durable: true
+        durable: false
         metadata:
           bullets:
           - Single S3 bucket

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -122,6 +122,18 @@ jobs:
         SERVICE_INSTANCE_NAME: s3-acceptance-test-public
         IS_PUBLIC: "true"
         ENCRYPTION: *encryption
+    - task: acceptance-tests-public-delete
+      file: broker-config/tasks/acceptance-tests.yml
+      params:
+        <<: *staging-cf-creds
+        APP_NAME: s3-acceptance-test-public
+        SERVICE_NAME: s3
+        PLAN_NAME: basic-public-sandbox
+        SERVICE_INSTANCE_NAME: s3-acceptance-test-public
+        IS_PUBLIC: "true"
+        IS_DELETE: "true"
+        ENCRYPTION: *encryption
+      
 
 - name: push-s3-broker-production
   serial: true

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -126,10 +126,10 @@ jobs:
       file: broker-config/tasks/acceptance-tests.yml
       params:
         <<: *staging-cf-creds
-        APP_NAME: s3-acceptance-test-public
+        APP_NAME: s3-acceptance-test-public-delete
         SERVICE_NAME: s3
         PLAN_NAME: basic-public-sandbox
-        SERVICE_INSTANCE_NAME: s3-acceptance-test-public
+        SERVICE_INSTANCE_NAME: s3-acceptance-test-public-delete
         IS_PUBLIC: "true"
         IS_DELETE: "true"
         ENCRYPTION: *encryption


### PR DESCRIPTION
Documentented the policy change here https://github.com/18F/cg-site/pull/1334.  The broker source code was also modified and ready to view here: https://github.com/cloudfoundry-community/s3-broker/pulls.

Sandbox accounts will only have the new S3 service plans available to provision, this will be done in accordance with the documentation outlined here: https://docs.cloudfoundry.org/services/access-control.html.  