### PR TITLE
Move anchors to top

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,4 +1,18 @@
 ---
+staging-cf-creds: &staging-cf-creds
+  CF_API_URL: ((staging-cf-api-url))
+  CF_USERNAME: ((staging-cf-username))
+  CF_PASSWORD: ((staging-cf-password))
+  CF_ORGANIZATION: ((staging-cf-organization))
+  CF_SPACE: ((staging-cf-space))
+
+production-cf-creds: &production-cf-creds
+  CF_API_URL: ((production-cf-api-url))
+  CF_USERNAME: ((production-cf-username))
+  CF_PASSWORD: ((production-cf-password))
+  CF_ORGANIZATION: ((production-cf-organization))
+  CF_SPACE: ((production-cf-space))
+
 jobs:
 - name: test-s3-broker
   plan:
@@ -362,17 +376,3 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook-url))
-
-staging-cf-creds: &staging-cf-creds
-  CF_API_URL: ((staging-cf-api-url))
-  CF_USERNAME: ((staging-cf-username))
-  CF_PASSWORD: ((staging-cf-password))
-  CF_ORGANIZATION: ((staging-cf-organization))
-  CF_SPACE: ((staging-cf-space))
-
-production-cf-creds: &production-cf-creds
-  CF_API_URL: ((production-cf-api-url))
-  CF_USERNAME: ((production-cf-username))
-  CF_PASSWORD: ((production-cf-password))
-  CF_ORGANIZATION: ((production-cf-organization))
-  CF_SPACE: ((production-cf-space))


### PR DESCRIPTION
Anchors are now required to be at the beginning of a pipeline file.

Requires no pipeline update in concourse.